### PR TITLE
[Bugfix] Sort the recommendations by descending value

### DIFF
--- a/src/main/java/de/hpi/msd/salsa/algorithm/Salsa.java
+++ b/src/main/java/de/hpi/msd/salsa/algorithm/Salsa.java
@@ -47,7 +47,7 @@ public class Salsa {
                 .entrySet()
                 .stream()
                 .filter(entry -> graph.getLeftNodeNeighbors(rootNode).contains(entry.getKey()))
-                .sorted(Map.Entry.comparingByValue())
+                .sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
                 .limit(limit)
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## Description
The default sorting order in Java is ascending. In the case of the SALSA results, the sorting leads to tweets with the leasts visits being recommended. This change reverses the sorting order to descending.

I found the issue when choosing different limits on the recommendation endpoint and got different results. Now, the ranking is not consistent when choosing different limit values.