### PR TITLE
[Bugfix] Fix compilation error caused by jdk 11

### DIFF
--- a/src/main/java/de/hpi/msd/salsa/index/DistributedBipartiteGraph.java
+++ b/src/main/java/de/hpi/msd/salsa/index/DistributedBipartiteGraph.java
@@ -46,7 +46,7 @@ public class DistributedBipartiteGraph implements BipartiteGraph {
             return client
                     .target(hostInfo.toString()).request("/leftNode/" + nodeId + "/neighborhood", MediaType.APPLICATION_JSON)
                     .get()
-                    .readEntity(new GenericType<>() {
+                    .readEntity(new GenericType<List<Long>>() {
                     });
         } else {
             return internalGraph.getLeftNodeNeighbors(nodeId);
@@ -65,7 +65,7 @@ public class DistributedBipartiteGraph implements BipartiteGraph {
             return client
                     .target(hostInfo.toString()).request("/rightNode/" + nodeId + "/neighborhood", MediaType.APPLICATION_JSON)
                     .get()
-                    .readEntity(new GenericType<>() {
+                    .readEntity(new GenericType<List<Long>>() {
                     });
         } else {
             return internalGraph.getRightNodeNeighbors(nodeId);


### PR DESCRIPTION
JDK 11 compiler crashes with NEP using diamond operator and JAX-RS's
GenericType (see https://bugs.openjdk.java.net/browse/JDK-8203913).
Therefore, I added the type.