### PR TITLE
Bugfix: RightIndex mutiple inserts

### DIFF
--- a/src/main/java/de/hpi/msd/salsa/processor/EdgeProcessor.java
+++ b/src/main/java/de/hpi/msd/salsa/processor/EdgeProcessor.java
@@ -27,9 +27,8 @@ public class EdgeProcessor extends AbstractProcessor<byte[], Edge> {
         AdjacencyList tweets = getAdjacencyList(edge.getUserId(), edge.getTweedId(), leftIndex);
         leftIndex.put(edge.getUserId(), tweets);
 
-        for (Long tweetId : tweets.getNeighbors()) {
-            rightIndex.put(tweetId, getAdjacencyList(tweetId, edge.getUserId(), rightIndex));
-        }
+        AdjacencyList user = getAdjacencyList(edge.getTweedId(), edge.getUserId(), rightIndex);
+        rightIndex.put(edge.getTweedId(), user);
 
         context().forward(edge.getUserId(), tweets);
     }

--- a/src/main/java/de/hpi/msd/salsa/processor/SamplingEdgeProcessor.java
+++ b/src/main/java/de/hpi/msd/salsa/processor/SamplingEdgeProcessor.java
@@ -33,10 +33,8 @@ public class SamplingEdgeProcessor extends AbstractProcessor<byte[], Edge> {
         SampledAdjacencyList tweets = reservoirSampling(edge.getUserId(), edge.getTweedId(), leftIndex);
         leftIndex.put(edge.getUserId(), tweets);
 
-        for (Long tweetId : tweets.getNeighbors()) {
-            SampledAdjacencyList list = reservoirSampling(tweetId, edge.getUserId(), rightIndex);
-            rightIndex.put(tweetId, list);
-        }
+        SampledAdjacencyList user = reservoirSampling(edge.getTweedId(), edge.getUserId(), rightIndex);
+        rightIndex.put(edge.getTweedId(), user);
 
         context().forward(edge.getUserId(), tweets);
     }

--- a/src/test/java/de/hpi/msd/salsa/processor/EdgeProcessorTest.java
+++ b/src/test/java/de/hpi/msd/salsa/processor/EdgeProcessorTest.java
@@ -35,6 +35,19 @@ class EdgeProcessorTest {
     }
 
     @Test
+    void testRightIndex() {
+        testTopology.input()
+                .add(new Edge(2L, 200L, 5))
+                .add(new Edge(2L, 300L, 5))
+                .add(new Edge(2L, 400L, 5))
+                .add(new Edge(2L, 500L, 5))
+                .add(new Edge(2L, 600L, 5));
+
+        KeyValueStore<Long, AdjacencyList> index = testTopology.getTestDriver().getKeyValueStore(EdgeToAdjacencyApp.RIGHT_INDEX_NAME);
+        Assertions.assertEquals(Collections.singletonList(2L), index.get(200L).getNeighbors());
+    }
+
+    @Test
     void shouldAddUserToTweeAdjacencyList() {
         testTopology.input().add(new Edge(2L, 200L, 5));
 

--- a/src/test/java/de/hpi/msd/salsa/processor/SamplingEdgeProcessorTest.java
+++ b/src/test/java/de/hpi/msd/salsa/processor/SamplingEdgeProcessorTest.java
@@ -94,6 +94,19 @@ class SamplingEdgeProcessorTest {
     }
 
     @Test
+    void testRightIndex() {
+        testTopology.input()
+                .add(new Edge(2L, 200L, 5))
+                .add(new Edge(2L, 300L, 5))
+                .add(new Edge(2L, 400L, 5))
+                .add(new Edge(2L, 500L, 5))
+                .add(new Edge(2L, 600L, 5));
+
+        KeyValueStore<Long, SampledAdjacencyList> index = testTopology.getTestDriver().getKeyValueStore(EdgeToAdjacencyApp.RIGHT_INDEX_NAME);
+        Assertions.assertEquals(Collections.singletonList(2L), index.get(200L).getNeighbors());
+    }
+
+    @Test
     void shouldGetSchemaRegistryClient() {
         Assertions.assertNotNull(this.testTopology.getSchemaRegistry());
     }


### PR DESCRIPTION
The user id of an incoming edge was added to every neighbor's adjacency list insteadt of just the current tweets