### PR TITLE
[Feature] Add SALSA GET parameters and default values

### DIFF
--- a/src/main/java/de/hpi/msd/salsa/rest/RecommendationRestService.java
+++ b/src/main/java/de/hpi/msd/salsa/rest/RecommendationRestService.java
@@ -19,7 +19,11 @@ public class RecommendationRestService {
     @GET
     @Path("/salsa/{userId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<Long> getRecommendationsForUser(@PathParam("userId") final long userId, @QueryParam("limit") final int limit) {
-        return new Salsa(graph, new Random()).compute(userId, 1000, 100, 0.1, limit);
+    public List<Long> getRecommendationsForUser(@PathParam("userId") final long userId,
+                                                @DefaultValue("10") @QueryParam("limit") final int limit,
+                                                @DefaultValue("1000") @QueryParam("walks") final int walks,
+                                                @DefaultValue("100") @QueryParam("walkLength") final int walkLength,
+                                                @DefaultValue("0.1") @QueryParam("resetProbability") final float resetProbability) {
+        return new Salsa(graph, new Random()).compute(userId, walks, walkLength, resetProbability, limit);
     }
 }


### PR DESCRIPTION
This PR introduces GET parameters into the REST API for the SALSA algorithm so that they can be varied during evaluation. This PR requires a redeployment of current Kubernetes systems.